### PR TITLE
Uses a do block for the instrumentation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ defmodule ArithmeticPipeline do
   step :double, with: &(&1 * 2)
   step :triple, with: &(&1 * 3)
 
-  instrument :before_stage, fn %{input: input} ->
+  instrument :before_stage, %{input: input} do
     IO.inspect input
   end
 
   # Will be called only for the matching stage
-  instrument :stage_completed, %{stage: %{name: :triple}}, fn %{time: time} ->
+  instrument :stage_completed, %{stage: %{name: :triple}}, %{time: time} do
     # send to the monitoring tool of your choice
   end
 end

--- a/lib/opus/instrumentation.ex
+++ b/lib/opus/instrumentation.ex
@@ -1,6 +1,14 @@
 defmodule Opus.Instrumentation do
   @moduledoc false
 
+  defmacro instrument(event, do: block) do
+    quote do
+      @doc false
+      def instrument(unquote(event), _, _), do: unquote(block)
+    end
+  end
+
+  # Deprecated Opus syntax, causes dialyzer failures
   defmacro instrument(event, fun) do
     handling = __MODULE__.definstrument(fun)
 
@@ -10,12 +18,27 @@ defmodule Opus.Instrumentation do
     end
   end
 
+  defmacro instrument(event, opts, do: block) do
+    quote do
+      @doc false
+      def instrument(unquote(event), unquote(opts), _), do: unquote(block)
+    end
+  end
+
+  # Deprecated Opus syntax, causes dialyzer failures
   defmacro instrument(event, opts, fun) do
     handling = __MODULE__.definstrument(fun)
 
     quote do
       @doc false
       def instrument(unquote(event), unquote(opts), metrics), do: unquote(handling)
+    end
+  end
+
+  defmacro instrument(event, opts, metrics, do: block) do
+    quote do
+      @doc false
+      def instrument(unquote(event), unquote(opts), unquote(metrics)), do: unquote(block)
     end
   end
 

--- a/test/opus/instrumentation_test.exs
+++ b/test/opus/instrumentation_test.exs
@@ -9,31 +9,33 @@ defmodule Opus.InstrumentationTest do
     step :add_three, with: &(&1 + 3), if: fn _ -> false end
     step :add_four, with: &(&1 + 4), instrument?: false
 
-    instrument :before_stage, info, fn
-      %{stage: _stage, input: -1} ->
-        raise "oh noes"
+    instrument :before_stage, info, %{stage: _stage} = metrics do
+      case metrics do
+        %{input: -1} ->
+          raise "oh noes"
 
-      %{stage: _stage} = metrics ->
-        send :instrumentation_test,
-             {:erlang.unique_integer([:positive]), :before_stage, info, metrics}
+        _ ->
+          send :instrumentation_test,
+               {:erlang.unique_integer([:positive]), :before_stage, info, metrics}
+      end
     end
 
-    instrument :stage_completed, info, fn %{time: _time} = metrics ->
+    instrument :stage_completed, info, %{time: _time} = metrics do
       send :instrumentation_test,
            {:erlang.unique_integer([:positive]), :stage_completed, info, metrics}
     end
 
-    instrument :stage_skipped, info, fn %{stage: _stage} = metrics ->
+    instrument :stage_skipped, info, %{stage: _stage} = metrics do
       send :instrumentation_test,
            {:erlang.unique_integer([:positive]), :stage_skipped, info, metrics}
     end
 
-    instrument :pipeline_started, info, fn args ->
+    instrument :pipeline_started, info, args do
       send :instrumentation_test,
            {:erlang.unique_integer([:positive]), :pipeline_started, info, args}
     end
 
-    instrument :pipeline_completed, info, fn args ->
+    instrument :pipeline_completed, info, args do
       send :instrumentation_test,
            {:erlang.unique_integer([:positive]), :pipeline_completed, info, args}
     end


### PR DESCRIPTION
This avoids generating dead code that dialyzer complains about.

e.g.
```
lib/myapp/pipeline.ex:49:guard_fail
Guard test:
is_function((_ -> :ok | {:error, _}), 0)

can never succeed.
```

Dialyzer is complaining because:
```elixir
  def definstrument(fun) do
    quote do
      case unquote(fun) do
        f when is_function(f, 0) -> f.()
        f when is_function(f, 1) -> f.(metrics)
      end
    end
  end
```
where `f` is a constant for this code. `f` will either always match the first, or the second, or neither and Dialyzer knows this from compile-time.

I tried to extract the `is_function()` logic outside of `quote`, but…there are too many function syntaxes (`fn -> … end`, `fn x -> … end`, `&f/0`, `&f/1`, `&(f(&1))`) to cleanly match on. So short of evaluating the AST to see if it results in a function of arity 0 or 1, I'm not sure what else to do.

I did notice that when providing an external module, one implements the underlying `instrument/3`, and that's basically what this PR does: allow to pass-through the `defmacro instrument` even inside an `Opus.Pipeline`.

Thoughts? :)

(And thanks for Opus! It made a chunk of our pipline-style code WAY SIMPLER!