### PR TITLE
Update PipelineErorr typespec

### DIFF
--- a/lib/opus/pipeline_error.ex
+++ b/lib/opus/pipeline_error.ex
@@ -4,7 +4,7 @@ defmodule Opus.PipelineError do
   """
 
   @type t :: %__MODULE__{
-          error: struct,
+          error: any,
           input: any,
           pipeline: module,
           stage: atom,


### PR DESCRIPTION
So in order to fail a stage we can raise an exception or return an `{:error, whatever}` tuple or just `:error` I believe too.

In the first case this exception will be caught and indeed `PipelineErorr`'s `:error` field will contain a struct of the exception.

If you, however, fail the stage by returning error tuple, the field will contain whatever you returned.

The same situation also happens when you fail a check by returning `false`. In that case we'll see something like: `%Opus.PipelineError{error: :failed_check_verify_signature}`, i.e. atom and not a struct.

I don't think we can predict what type precisely will be there, so I think the best is to return any?